### PR TITLE
更换Wiki网址

### DIFF
--- a/ul.html
+++ b/ul.html
@@ -17,7 +17,7 @@
 <p><center><font size="5"><a href="https://www.mcmod.cn/rand" target="_blank">MC百科随机页面</a></font></center></p>
 <p><center><font size="5"><a href="https://www.mcmod.cn/item/303153.html" target="_blank">MC百科试验性条目</a></font></center></p>
 <p><center><font size="5"><a href="https://www.mcbbs.net/" target="_blank">MCBBS</a></font></center></p>
-<p><center><font size="5"><a href="https://minecraft.fandom.com/zh/wiki/Minecraft_Wiki" target="_blank">Minecraft Wiki</a></font></center></p>
+<p><center><font size="5"><a href="https://zh.minecraft.wiki/" target="_blank">Minecraft Wiki</a></font></center></p>
 <p><center><font size="5"><a href="http://minecraft.novaskin.me/wallpapers" target="_blank">MC背景制作</a></font></center></p>
 <p><center><font size="5"><a href="https://mc-map.djfun.de/" target="_blank">MC地图像素画制作</a></font></center></p>
 <p><center><font size="5"><a href="https://minecraft.tools/en/" target="_blank">Minecraft工具</a></font></center></p>


### PR DESCRIPTION
MinecraftWiki现已搬迁，请求更换网址